### PR TITLE
Prefer python3 during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ For backwards compatibility, the role will automatically detect existing
 installation in `~/opt/google-cloud-sdk` and default to this location
 if found.
 
+## Prefer Python 3
+
+The current Google Cloud SDK installer will look for available Python versions
+and prefer `python2` over `python3`.
+
+You can enable `python3` to be preferred over `python2` during install.
+
+```yaml
+gcloud_prefer_python3: true
+```
+
 ## Install using package manager
 
 To install Cloud SDK from the package manager where available, enable it in

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,9 @@ gcloud_debug: true
 # Cloud SDK version to install
 gcloud_version: "271.0.0"
 
+# Prefer python3 during install
+gcloud_prefer_python3: false
+
 # Setup shell init scripts
 gcloud_setup_shell: true
 

--- a/templates/run_install.sh.j2
+++ b/templates/run_install.sh.j2
@@ -1,3 +1,30 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-{{ gcloud_install_path }}/google-cloud-sdk/install.sh --quiet --usage-reporting {{ gcloud_usage_reporting | lower }} {% if gcloud_profile_path %}--rc-path {{ gcloud_profile_path }} {% endif %} --command-completion {{ gcloud_command_completion | lower }} --path-update {{ gcloud_update_path | lower }} {% if gcloud_override_components | length > 0 %}--override-components {% for component in gcloud_override_components %}{{ component }}{% if loop.index < gcloud_override_components | length  %} {% endif %}{% endfor %} {% endif %}{% if gcloud_additional_components | length > 0 %}--additional-components {% for component in gcloud_additional_components %}{{ component }}{% if loop.index < gcloud_additional_components | length %} {% endif %}{% endfor %}{% endif %}
+_gcloud_is_python_installed() {
+    local binary="$1"
+    if ! command -v "${binary}" 2>/dev/null; then
+        return 1
+    fi
+    local version
+    version=$("${binary}" --version 2>/dev/null)
+    if [ -z "${version}" ]; then
+        return 1
+    fi
+}
+
+{% if gcloud_prefer_python3 | bool %}
+if _gcloud_is_python_installed python3; then
+    export CLOUDSDK_PYTHON=python3
+elif _gcloud_is_python_installed python2; then
+    export CLOUDSDK_PYTHON=python2
+fi
+{% endif %}
+
+{{ gcloud_install_path }}/google-cloud-sdk/install.sh \
+    --quiet \
+    --usage-reporting {{ gcloud_usage_reporting | lower }} \
+    {% if gcloud_profile_path %}--rc-path {{ gcloud_profile_path }} {% endif %} \
+    --command-completion {{ gcloud_command_completion | lower }} \
+    --path-update {{ gcloud_update_path | lower }} \
+    {% if gcloud_override_components | length > 0 %}--override-components {% for component in gcloud_override_components %}{{ component }}{% if loop.index < gcloud_override_components | length %} {% endif %}{% endfor %} {% endif %} \
+    {% if gcloud_additional_components | length > 0 %}--additional-components {% for component in gcloud_additional_components %}{{ component }}{% if loop.index < gcloud_additional_components | length %} {% endif %}{% endfor %}{% endif %}


### PR DESCRIPTION
Added configuration option to prefer python3 during install:

```yaml
gcloud_prefer_python3: true
```

Looking at the installation script, this seems to be the the default on Google's internal environments but not for the rest of the users.

Fix issues with pyenv shims during install by checking python version in addition to if the command exists.